### PR TITLE
- Remove Linq based code and change TargetFrameworkVersion to v2.0 instead of v3.5

### DIFF
--- a/Cyotek.Windows.Forms.ImageBox.Demo/Cyotek.Windows.Forms.ImageBox.Demo.csproj
+++ b/Cyotek.Windows.Forms.ImageBox.Demo/Cyotek.Windows.Forms.ImageBox.Demo.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cyotek.Windows.Forms.Demo</RootNamespace>
     <AssemblyName>imgbxdmo</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
@@ -44,7 +44,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />

--- a/Cyotek.Windows.Forms.ImageBox.Demo/PropertyGrid.cs
+++ b/Cyotek.Windows.Forms.ImageBox.Demo/PropertyGrid.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace Cyotek.Windows.Forms
@@ -36,7 +35,10 @@ namespace Cyotek.Windows.Forms
         if (checkItem.Label == itemLabel)
           matchingItem = checkItem;
 
-        searchItems.AddRange(checkItem.GridItems.Cast<GridItem>());
+        foreach (GridItem item in checkItem.GridItems)
+        {
+          searchItems.Add(item);
+        }
       }
 
       return matchingItem;

--- a/Cyotek.Windows.Forms.ImageBox.Design/Cyotek.Windows.Forms.ImageBox.Design.csproj
+++ b/Cyotek.Windows.Forms.ImageBox.Design/Cyotek.Windows.Forms.ImageBox.Design.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cyotek.Windows.Forms.ImageBox.Design</RootNamespace>
     <AssemblyName>Cyotek.Windows.Forms.ImageBox.Design</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -31,11 +31,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Design" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/Cyotek.Windows.Forms.ImageBox/Cyotek.Windows.Forms.ImageBox.csproj
+++ b/Cyotek.Windows.Forms.ImageBox/Cyotek.Windows.Forms.ImageBox.csproj
@@ -9,9 +9,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cyotek.Windows.Forms</RootNamespace>
     <AssemblyName>Cyotek.Windows.Forms.ImageBox</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,7 +40,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/Cyotek.Windows.Forms.ImageBox/ZoomLevelCollection.cs
+++ b/Cyotek.Windows.Forms.ImageBox/ZoomLevelCollection.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Cyotek.Windows.Forms
 {
@@ -149,8 +148,10 @@ namespace Cyotek.Windows.Forms
     /// <param name="arrayIndex">A 64-bit integer that represents the index in the <see cref="Array"/> at which storing begins.</param>
     public void CopyTo(int[] array, int arrayIndex)
     {
-      if (this.Count != 0)
-        Array.Copy(this.List.Values.ToArray(), 0, array, arrayIndex, this.Count);
+      for (int i = 0; i < this.Count; i++)
+      {
+        array[arrayIndex + i] = this.List.Values[i]; 
+      }
     }
 
     /// <summary>
@@ -159,7 +160,19 @@ namespace Cyotek.Windows.Forms
     /// <param name="zoomLevel">The zoom level.</param>
     public int FindNearest(int zoomLevel)
     {
-      return this.OrderBy(v => Math.Abs(v - zoomLevel)).First();
+      int nearestValue = this.List.Values[0];
+      int nearestDifference = Math.Abs(nearestValue - zoomLevel);
+      for (int i = 1; i < this.Count; i++)
+      {
+         int value = this.List.Values[i];
+         int difference = Math.Abs(value - zoomLevel);
+         if (difference < nearestDifference)
+         {
+            nearestValue = value;
+            nearestDifference = difference;
+         }
+      }
+      return nearestValue;
     }
 
     /// <summary>


### PR DESCRIPTION
Since there was minimal use of v3.5 features (and both v3.5 and v2.0 both use the .Net 2.0 CLR) it makes sense to rebuild this without any of the extra 3.5 libraries pulled in to let more people make use of this library in a .Net 2.0 only context.
