### PR TITLE
Added mouse wheel mode to allow scrolling and zooming with mouse wheel

### DIFF
--- a/Cyotek.Windows.Forms.ImageBox/Cyotek.Windows.Forms.ImageBox.csproj
+++ b/Cyotek.Windows.Forms.ImageBox/Cyotek.Windows.Forms.ImageBox.csproj
@@ -48,6 +48,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="ImageBoxMouseWheelMessageFilter.cs" />
+    <Compile Include="ImageBoxMouseWheelMode.cs" />
     <Compile Include="ImageBoxPanMode.cs" />
     <Compile Include="ImageBoxPanStyle.cs" />
     <Compile Include="ImageBoxZoomActions.cs" />

--- a/Cyotek.Windows.Forms.ImageBox/ImageBox.cs
+++ b/Cyotek.Windows.Forms.ImageBox/ImageBox.cs
@@ -1408,7 +1408,7 @@ namespace Cyotek.Windows.Forms
     /// Gets or sets the how the mouse wheel is handled
     /// </summary>
     /// <value>
-    /// The pan mode.
+    /// The mouse wheel mode.
     /// </value>
     [Category("Behavior")]
     [DefaultValue(typeof(ImageBoxMouseWheelMode), "Zoom")]

--- a/Cyotek.Windows.Forms.ImageBox/ImageBoxMouseWheelMode.cs
+++ b/Cyotek.Windows.Forms.ImageBox/ImageBoxMouseWheelMode.cs
@@ -6,6 +6,11 @@ namespace Cyotek.Windows.Forms
   public enum ImageBoxMouseWheelMode
   {
     /// <summary>
+    /// Mouse wheel not handled
+    /// </summary>
+    None,
+
+    /// <summary>
     /// Mouse wheel zooms
     /// </summary>
     Zoom,

--- a/Cyotek.Windows.Forms.ImageBox/ImageBoxMouseWheelMode.cs
+++ b/Cyotek.Windows.Forms.ImageBox/ImageBoxMouseWheelMode.cs
@@ -1,0 +1,18 @@
+namespace Cyotek.Windows.Forms
+{
+  /// <summary>
+  /// Specifies the way the mouse wheel is handled for the <see cref="ImageBox"/> control.
+  /// </summary>
+  public enum ImageBoxMouseWheelMode
+  {
+    /// <summary>
+    /// Mouse wheel zooms
+    /// </summary>
+    Zoom,
+
+    /// <summary>
+    /// Mouse wheel scrolls vertically, Shift + mouse wheel scrolls horizontally and Ctrl + mouse wheel zooms
+    /// </summary>
+    ScrollAndZoom
+  }
+}


### PR DESCRIPTION
A very common way to use mouse wheel for zooming and scrolling is

- Mouse wheel scrolls vertically
- Shift + mouse wheel scrolls horizontally
- Ctrl + mouse wheel zooms

Well known tools and enterprise software implemented this way of using the mouse wheel. So it could be confusing and necessary to use this way of using the mous wheel here too.

To ensure the old way is also still possible an additional property for selecting the mode is added.