### PR TITLE
Additionally check if "Free pan" conditions are met before starting a…

### DIFF
--- a/Cyotek.Windows.Forms.ImageBox/ImageBox.cs
+++ b/Cyotek.Windows.Forms.ImageBox/ImageBox.cs
@@ -4025,7 +4025,10 @@ namespace Cyotek.Windows.Forms
         else
         {
           _mouseDownStart = NativeMethods.GetTickCount();
-          this.ProcessPanning(e);
+          if (AllowFreePan && e.Button is MouseButtons.Middle)
+          {
+            this.ProcessPanning(e);
+          }
         }
       }
 


### PR DESCRIPTION
… panning. This will fix IsPanning value inside the Click event handler. Fixes #50.